### PR TITLE
Option for authentification mode

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,8 @@ var internals = {
     defaults: {
         docsPath: '/docs',
         indexTemplatePath: __dirname + '/../templates/index.html',
-        routeTemplatePath: __dirname + '/../templates/route.html'
+        routeTemplatePath: __dirname + '/../templates/route.html',
+        auth: false
     }
 };
 
@@ -28,7 +29,8 @@ exports.register = function (pack, options, next) {
 
     var resources = {
         compiledIndexTemplate: Handlebars.compile(indexTemplateSource),
-        compiledRouteTemplate: Handlebars.compile(routeTemplateSource)
+        compiledRouteTemplate: Handlebars.compile(routeTemplateSource),
+        auth: settings.auth
     };
 
     pack.route({ method: 'GET', path: settings.docsPath, config: internals.docs(resources) });
@@ -40,6 +42,7 @@ exports.register = function (pack, options, next) {
 internals.docs = function (resources) {
 
     return {
+        auth: resources.auth,
         validate: {
             query: {
                 path: Joi.types.String()


### PR DESCRIPTION
Following #14

When using Hapi with a defaultMode of authentication, the docs are not accessible.
This puts the authentication to false on the route added by Lout by default, and let the user set a mode (as described in Hapi's route config) via the options.
