### PR TITLE
Display description and payload

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -97,11 +97,11 @@ internals.getRoutesData = function (routes) {
         routesData.push({
             path: route.path,
             method: route.method.toUpperCase(),
-            description: route.description,
-            notes: route.notes,
-            tags: route.tags,
+            description: route.settings.description,
+            notes: route.settings.notes,
+            tags: route.settings.tags,
             queryParams: internals.getParamsData(route.settings.validate && route.settings.validate.query),
-            payloadParams: internals.getParamsData(route.settings.validate && route.settings.validate.schema),
+            payloadParams: internals.getParamsData(route.settings.validate && route.settings.validate.payload),
             responseParams: internals.getParamsData(route.settings.response)
         });
     });


### PR DESCRIPTION
Updated the locations of the description, notes and tags to work with the latest Hapi. Changed schema to payload for Hapi >=0.17.0
