### PR TITLE
fixing sort logic

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -55,7 +55,13 @@ internals.docs = function (settings, plugin) {
 
             routes.sort(function (route1, route2) {
 
-                return route1.path > route2.path;
+                if (route1.path > route2.path) {
+                    return 1;
+                }
+                if (route1.path < route2.path) {
+                    return -1;
+                }
+                return 0;
             });
 
             if (request.query.path) {


### PR DESCRIPTION
The existing logic for sorting the routes was slightly flawed, which in some cases would cause the routes to be listed out of (alphabetical) order.
