### PR TITLE
fixing sort logic

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -55,7 +55,13 @@ internals.docs = function (settings, plugin) {
 
             routes.sort(function (route1, route2) {
 
-                return route1.path > route2.path;
+                if (route1.path > route2.path) {
+                    return 1;
+                }
+                if (route1.path < route2.path) {
+                    return -1;
+                }
+                return 0;
             });
 
             if (request.query.path) {

--- a/test/index.js
+++ b/test/index.js
@@ -33,6 +33,8 @@ describe('Lout', function () {
 
         server.route([
             { method: 'GET', path: '/test', config: { handler: handler, validate: { query: { param1: S().required() } } } },
+            { method: 'GET', path: '/another/test', config: { handler: handler, validate: { query: { param1: S().required() } } } },
+            { method: 'GET', path: '/zanother/test', config: { handler: handler, validate: { query: { param1: S().required() } } } },
             { method: 'POST', path: '/test', config: { handler: handler, validate: { query: { param2: S().valid('first', 'last') } } } },
             { method: 'GET', path: '/notincluded', config: { handler: handler, plugins: { lout: false } } }
         ]);


### PR DESCRIPTION
The existing logic for sorting the routes was slightly flawed, which in some cases would cause the routes to be listed out of (alphabetical) order.
