### PR TITLE
Fix response param settings path lookup

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -96,7 +96,7 @@ internals.getRoutesData = function (routes) {
             pathParams: internals.getParamsData(route.settings.validate && route.settings.validate.path),
             queryParams: internals.getParamsData(route.settings.validate && route.settings.validate.query),
             payloadParams: internals.getParamsData(route.settings.validate && route.settings.validate.payload),
-            responseParams: internals.getParamsData(route.settings.validate && route.settings.validate.response && route.settings.validate.response.schema)
+            responseParams: internals.getParamsData(route.settings.response && route.settings.response.schema)
         });
     });
 


### PR DESCRIPTION
Hi,

Now that response validation settings have moved up a level, lout doesn't find them anymore.

By the way, can someone explain me the design decision behind moving this specific validation out of the other validations ?
