### PR TITLE
Handle deepness in validation objects

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,7 @@ exports.register = function (plugin, options, next) {
 
     var settings = plugin.hapi.utils.applyToDefaults(internals.defaults, options || {});
 
-    plugin.views({ engines: settings.engines, path: './templates', basePath: settings.basePath });
+    plugin.views({ engines: settings.engines, path: './templates', basePath: settings.basePath, partialsPath: './templates' });
     plugin.route({ method: 'GET', path: settings.endpoint, config: internals.docs(settings, plugin) });
 
     next();
@@ -128,7 +128,8 @@ internals.getParamsData = function (params) {
             type: param.type,
             required: param.__modifiers && param.__modifiers._values ? param.__modifiers._values.some(internals.isRequiredParam) : null,
             allowedValues: param.__valids ? internals.getExistsValues(param.__valids._exists) : null,
-            disallowedValues: param.__invalids ? internals.getExistsValues(param.__invalids._exists) : null
+            disallowedValues: param.__invalids ? internals.getExistsValues(param.__invalids._exists) : null,
+            subType: param.type === 'Object' ? internals.getParamsData(param._config) : null
         });
     }
 

--- a/templates/route.html
+++ b/templates/route.html
@@ -58,32 +58,7 @@
                 <dd>
                     <ul class="unstyled">
                         {{#each this.queryParams}}
-                        <li>
-                            <h5><em>{{this.name}}</em>
-                                {{#if this.required}}
-                                <i class="icon-star"></i>
-                                {{/if}}
-                            </h5>
-                            {{#if this.description}}
-                            <p>{{this.description}}</p>
-                            {{/if}}
-                            <dl>
-                                <dt><h6>Type</h6></dt>
-                                <dd>{{this.type}}</dd>
-                                {{#if this.allowedValues}}
-                                    <dt>Allowed Values</dt>
-                                    {{#each this.allowedValues}}
-                                        <dd>{{this}}</dd>
-                                    {{/each}}
-                                {{/if}}
-                                {{#if this.disallowedValues}}
-                                    <dt>Forbidden Values</dt>
-                                    {{#each this.disallowedValues}}
-                                        <dd>{{this}}</dd>
-                                    {{/each}}
-                                {{/if}}
-                            </dl>
-                        </li>
+                            {{> type}}
                         {{/each}}
                     </ul>
                 </dd>
@@ -93,32 +68,7 @@
                 <dd>
                     <ul class="unstyled">
                         {{#each this.payloadParams}}
-                        <li>
-                            <h5><em>{{this.name}}</em>
-                                {{#if this.required}}
-                                <i class="icon-star"></i>
-                                {{/if}}
-                            </h5>
-                            {{#if this.description}}
-                            <p>{{this.description}}</p>
-                            {{/if}}
-                            <dl>
-                                <dt><h6>Type</h6></dt>
-                                <dd>{{this.type}}</dd>
-                                {{#if this.allowedValues}}
-                                    <dt>Allowed Values</dt>
-                                    {{#each this.allowedValues}}
-                                        <dd>{{this}}</dd>
-                                    {{/each}}
-                                {{/if}}
-                                {{#if this.disallowedValues}}
-                                    <dt>Forbidden Values</dt>
-                                    {{#each this.disallowedValues}}
-                                        <dd>{{this}}</dd>
-                                {{/each}}
-                                {{/if}}
-                            </dl>
-                        </li>
+                            {{> type}}
                         {{/each}}
                     </ul>
                 </dd>
@@ -128,32 +78,7 @@
             <dd>
                 <ul class="unstyled">
                     {{#each this.responseParams}}
-                    <li>
-                        <h4><em>{{this.name}}</em>
-                            {{#if this.required}}
-                            <i class="icon-star"></i>
-                            {{/if}}
-                        </h4>
-                        {{#if this.description}}
-                        <p>{{this.description}}</p>
-                        {{/if}}
-                        <dl>
-                            <dt>Type</dt>
-                            <dd>{{this.type}}</dd>
-                            {{#if this.allowedValues}}
-                            <dt>Allowed Values</dt>
-                            {{#each this.allowedValues}}
-                            <dd>{{this}}</dd>
-                            {{/each}}
-                            {{/if}}
-                            {{#if this.disallowedValues}}
-                            <dt>Forbidden Values</dt>
-                            {{#each this.disallowedValues}}
-                            <dd>{{this}}</dd>
-                            {{/each}}
-                            {{/if}}
-                        </dl>
-                    </li>
+                        {{> type}}
                     {{/each}}
                 </ul>
             </dd>

--- a/templates/type.html
+++ b/templates/type.html
@@ -1,0 +1,32 @@
+<li>
+    <h5><em>{{this.name}}</em>
+        {{#if this.required}}
+        <i class="icon-star"></i>
+        {{/if}}
+    </h5>
+    {{#if this.description}}
+    <p>{{this.description}}</p>
+    {{/if}}
+    <dl>
+        <dt><h6>Type</h6></dt>
+        <dd>{{this.type}}</dd>
+        {{#if this.allowedValues}}
+            <dt>Allowed Values</dt>
+            {{#each this.allowedValues}}
+                <dd>{{this}}</dd>
+            {{/each}}
+        {{/if}}
+        {{#if this.disallowedValues}}
+            <dt>Forbidden Values</dt>
+            {{#each this.disallowedValues}}
+                <dd>{{this}}</dd>
+            {{/each}}
+        {{/if}}
+        {{#if this.subType}}
+            <dt>Properties</dt>
+            {{#each this.subType}}
+                <dd>{{> type}}</dd>
+            {{/each}}
+        {{/if}}
+    </dl>
+</li>


### PR DESCRIPTION
Hi,

The documentation felt incomplete on the validation part when you have nested objects, so here's a fix.
I took the liberty (for simplicity's sake) to have the same template on `responseParams`, it was the only one who differed.
This might create long pages depending how nested your validations are, should I try to restyle it a bit to improve readability ?
