### PR TITLE
Avoid lout puking when there is an invalid Joi declaration.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,6 +20,16 @@ var internals = {
 };
 
 
+internals.Error = function (message) {
+
+    var self = this;
+
+    // Set the message and type
+    self.error = message;
+    self.type = 'error';
+}
+
+
 exports.register = function (plugin, options, next) {
 
     var settings = Hoek.applyToDefaults(internals.defaults, options);
@@ -199,6 +209,9 @@ internals.getParamsData = function (param, name) {
 
             data.rules[capitalizedName] = !Array.isArray(rule.arg) ? rule.arg : rule.arg.map(function (type) {
 
+                if (typeof type.isJoi === 'undefined') {
+                    return new internals.Error('Invalid Joi Declaration');
+                }
                 return internals.getParamsData(type.describe());
             });
         });

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -91,3 +91,7 @@ body {
 .route-details ul.reduced-margin-list {
   margin-left: -20px;
 }
+
+.route-error {
+  color: #FF0000;
+}

--- a/templates/type.html
+++ b/templates/type.html
@@ -42,6 +42,10 @@
                 </ul>
             </dd>
         {{/if}}
+        {{#if this.error}}
+            <dt>Message</dt>
+            <dd class="route-error">{{this.error}}</dd>
+        {{/if}}
         {{#each this.rules}}
             <dt>{{@key}}</dt>
             <dd>

--- a/test/index.js
+++ b/test/index.js
@@ -219,6 +219,15 @@ describe('Lout', function () {
         });
     });
 
+    it('should not error 500 on invalid joi object', function (done) {
+
+        server.inject('/docs?path=/invalidjoi', function (res) {
+
+            expect(res.result).to.contain('Invalid Joi Declaration');
+            done();
+        });
+    });
+
     describe('Index', function () {
 
         it('doesn\'t throw an error when requesting the index when there are no POST routes', function (done) {

--- a/test/routes/default.js
+++ b/test/routes/default.js
@@ -23,5 +23,6 @@ module.exports = [
     { method: 'GET', path: '/emptyobject', config: { handler: handler, validate: { query: { param1: t.object() } } } },
     { method: 'GET', path: '/alternatives', config: { handler: handler, validate: { query: { param1: t.alternatives(t.number().required(), t.string().valid('first', 'last')) }}}},
     { method: 'GET', path: '/novalidation', config: { handler: handler } },
-    { method: 'GET', path: '/withresponse', config: { handler: handler, response: { schema: { param1: t.string() } } } }
+    { method: 'GET', path: '/withresponse', config: { handler: handler, response: { schema: { param1: t.string() } } } },
+    { method: 'POST', path: '/invalidjoi', config: { handler: handler, validate: { payload: { param1: t.array().includes( { param2: t.string() } ) } } } }
 ];


### PR DESCRIPTION
I can generate a 500 with this potentially incorrect Joi declaration (I don't know if this is valid):

Incorrect declaration:

```
var schema = {
    a: Joi.string(),
    b: Joi.array().includes({
            x: Joi.string()
        }
    )
};
```

Correct declaration:

```
var schema = {
    a: Joi.string(),
    b: Joi.array().includes(
        Joi.object({
            x: Joi.string()
        })
    )
};
```

Lout should not 500 in this case but instead should show an error message.
