### PR TITLE
Make CSS path relative.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -43,7 +43,7 @@ exports.register = function (plugin, options, next) {
         helpersPath: settings.helpersPath,
         runtimeOptions: {
             data: {
-                cssBaseUrl: cssBaseUrl
+                cssBaseUrl: cssBaseUrl.replace(/^\//, '')
             }
         }
     });


### PR DESCRIPTION
We have hapi in a subdirectory (https://api.example.com/v1). With the default configuration lout sets the endpoint to `/docs` making the documentation available at https://api.example.com/v1/docs. The problem is that this same endpoint (`/docs`) is used for the CSS path, which results in a link:

```
<link href="/docs/css/style.css" rel="stylesheet">
```

This link expands to https://api.example.com/docs/css/style.css which results in 404 (`/v1` is missing in the URL). So I propose to make the CSS path relative to the endpoint route. If endpoint is `/docs`, then set CSS path to `docs`. Then link will become:

```
<link href="docs/css/style.css" rel="stylesheet">
```

This expands to https://api.example.com/v1/docs/css/style.css which is the correct URL.
