### PR TITLE
Added in a container div, fixed unnecessary containers around the navbar...

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -7,8 +7,10 @@
 </head>
 <body>
     <div class="navbar navbar-inverse navbar-fixed-top" role="navigation">
-        <div class="navbar-header">
-            <a class="navbar-brand" href="#">Route Documentation</a>
+        <div class="container">
+            <div class="navbar-header">
+                <a class="navbar-brand" href="#">Route Documentation</a>
+            </div>
         </div>
     </div>
     <div class="container route-index">

--- a/templates/route.html
+++ b/templates/route.html
@@ -7,19 +7,19 @@
 </head>
 <body>
     <nav class="navbar navbar-inverse navbar-fixed-top" role="navigation">
-        <div class="navbar-header">
-            <a class="navbar-brand" href="?"><i class="glyphicon glyphicon-home glyphicon-white"></i></a>
-            <div class="navbar-text">
-                <ul class="navbar-nav list-inline">
-                    {{#each routes}}
-                    <li>
-                        <a href="#{{this.method}}" class="anchor-link">
-                            <span class="{{colorFromMethod this}}">{{this.method}}</span>
-                        </a>
-                    </li>
-                    {{/each}}
-                </ul>
+        <div class="container">
+            <div class="navbar-header">
+                <a class="navbar-brand" href="?"><i class="glyphicon glyphicon-home glyphicon-white"></i></a>
             </div>
+            <ul class="nav navbar-nav">
+                {{#each routes}}
+                <li>
+                    <a href="#{{this.method}}" class="anchor-link">
+                        <span class="{{colorFromMethod this}}">{{this.method}}</span>
+                    </a>
+                </li>
+                {{/each}}
+            </ul>
         </div>
     </nav>
     <div class="container route-details">


### PR DESCRIPTION
... list. 

Summary: There is a bug where, on clicking on a route.html link on Chrome, the navbar will automatically drop to 100px height on refresh. This is due to non-standard navbar classes being specified. This PR fixes that. 
