### PR TITLE
Lout is failing on this particular nested Joi obj.

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -219,6 +219,15 @@ describe('Lout', function () {
         });
     });
 
+    it('should handle invalid array of rules', function (done) {
+
+        server.inject('/docs?path=/withinvalidrulesarray', function (res) {
+
+            expect(res.result).to.not.contain('Request Parameters');
+            done();
+        });
+    });
+
     describe('Index', function () {
 
         it('doesn\'t throw an error when requesting the index when there are no POST routes', function (done) {

--- a/test/routes/default.js
+++ b/test/routes/default.js
@@ -24,5 +24,6 @@ module.exports = [
     { method: 'GET', path: '/alternatives', config: { handler: handler, validate: { query: { param1: t.alternatives(t.number().required(), t.string().valid('first', 'last')) }}}},
     { method: 'GET', path: '/novalidation', config: { handler: handler } },
     { method: 'GET', path: '/withresponse', config: { handler: handler, response: { schema: { param1: t.string() } } } },
-    { method: 'GET', path: '/withpojoinarray', config: { handler: handler, validate: { query: { param1: t.array().includes( { param2: t.string() } ) } } } }
+    { method: 'GET', path: '/withpojoinarray', config: { handler: handler, validate: { query: { param1: t.array().includes( { param2: t.string() } ) } } } },
+    { method: 'POST', path: '/withinvalidrulesarray', config: { handler: handler, validate: { payload: { param1: Joi.array().includes( Joi.object( { param2: Joi.array().includes( Joi.object( { param3 : Joi.string() } ) ).optional() } ) ) } } } }
 ];


### PR DESCRIPTION
Here is a particular testcase where lout is failing on a rule object that is not an Array. 

```
validate: { 
    payload: { 
        param1: Joi.array().includes( Joi.object( { 
            param2: Joi.array().includes( Joi.object( { 
                param3 : Joi.string() } ) ).optional() 
            } ) 
         ) }
    } 
}
```

Simple fix would be to add protection, but I don't think that is the ideal solution.

```
@ln 193 index.js
} else if (data.type === 'array' && param.rules) {

        data.rules = {};

        param.rules.forEach(function (rule) {

            var capitalizedName = rule.name.charAt(0).toUpperCase() + rule.name.slice(1);

            if (Array.isArray(params.rule)) {
                data.rules[capitalizedName] = !Array.isArray(rule.arg) ? rule.arg : rule.arg.map(function (type) {

                    return internals.getParamsData(internals.describe(type));
                });
            }
        });
```
