### PR TITLE
Triple bracketed this.notes so that html can be parsed by the browser.

### DIFF
--- a/templates/route.html
+++ b/templates/route.html
@@ -49,7 +49,7 @@
                     {{/if}}
                     {{#if this.notes}}
                         <h3>Notes</h3>
-                        <p class="notes">{{this.notes}}</p>
+                        <p class="notes">{{{this.notes}}}</p>
                     {{/if}}
                     {{#if this.auth}}
                         <h3>Strategies</h3>


### PR DESCRIPTION
There's no reason to escape HTML in Notes, and it isn't useful to do so. 

I use the Notes field to display a valid response using JSON.stringify(). Example: 

```
notes: 'Valid response: <br/>' +
    '<pre><code>' +
    JSON.stringify(
      [
        {
          "example": "STRING",
        }
      ]
      , null, 4) +
    '</code></pre>',
```

In such cases, having just {{this.notes}} means that the browser can't parse it. I think we should trust the developers to know that the HTML here is safe. 
