### PR TITLE
Don't show payload params for GET route

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -149,7 +149,7 @@ internals.getRoutesData = function (routes) {
             auth: route.settings.auth && route.settings.auth.strategies,
             pathParams: internals.describe(route.settings.validate.params),
             queryParams: internals.describe(route.settings.validate.query),
-            payloadParams: internals.describe(route.settings.validate.payload),
+            payloadParams: route.method !== "get" ? internals.describe(route.settings.validate.payload) : null,
             responseParams: internals.describe(route.settings.response && route.settings.response.schema)
         });
     });

--- a/test/index.js
+++ b/test/index.js
@@ -91,7 +91,7 @@ describe('Lout', function () {
 
             var $ = cheerio.load(res.result);
 
-            expect($('dt h6').length).to.equal(7);
+            expect($('dt h6').length).to.equal(6);
 
             done();
         });
@@ -210,9 +210,23 @@ describe('Lout', function () {
         });
     });
 
-    it('should show routes without any validation', function (done) {
+    it('should show GET routes without any validation and no payload parameters', function (done) {
 
-        server.inject('/docs?path=/novalidation', function (res) {
+        server.inject('/docs?path=/novalidation_get', function (res) {
+
+            expect(res.result).to.contain('Request Parameters');
+            expect(res.result).to.contain('Query Parameters');
+
+            var $ = cheerio.load(res.result);
+            expect($('.type dd').text()).to.equal('anyany'); // any should appear 3 times
+
+            done();
+        });
+    });
+
+    it('should show other routes without any validation', function (done) {
+
+        server.inject('/docs?path=/novalidation_post', function (res) {
 
             expect(res.result).to.contain('Request Parameters');
             expect(res.result).to.contain('Query Parameters');

--- a/test/routes/default.js
+++ b/test/routes/default.js
@@ -165,7 +165,13 @@ module.exports = [{
   }
 }, {
   method: 'GET',
-  path: '/novalidation',
+  path: '/novalidation_get',
+  config: {
+    handler: handler
+  }
+}, {
+  method: 'POST',
+  path: '/novalidation_post',
   config: {
     handler: handler
   }


### PR DESCRIPTION
Lout by default shows Type any for Path, Query and Payload parameters,
but Hapi doesn't accept a payload for a GET request, this pull request
automatically hides the payload section.
