### PR TITLE
fix basePath in lout config

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,8 @@ var internals = {
         helpersPath: Path.join(__dirname, '../templates/helpers'),
         indexTemplate: 'index',
         routeTemplate: 'route',
-        methodsOrder: ['get', 'head', 'post', 'put', 'delete', 'trace']
+        methodsOrder: ['get', 'head', 'post', 'put', 'delete', 'trace'],
+        basePath: Path.join(__dirname, '../')
     }
 };
 
@@ -28,11 +29,11 @@ exports.register = function (plugin, options, next) {
     Hoek.merge(settings, options);
 
     var cssBaseUrl = (settings.endpoint === '/' ? '' : settings.endpoint) + '/css';
+    var basePath = Path.join(settings.basePath, './templates');
 
     plugin.views({
         engines: settings.engines || { html: { module: Handlebars } },
-        path: Path.join(__dirname, '../templates'),
-        basePath: settings.basePath,
+        path: basePath,
         partialsPath: Path.join(__dirname, '../templates'),
         helpersPath: settings.helpersPath,
         runtimeOptions: {


### PR DESCRIPTION
lib/index.js was loading the default lout index and route templates,
despite basePath being set. PR fixes this.
