### PR TITLE
validation query docs with joi 4.7.x

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -87,9 +87,9 @@ internals.docs = function (settings, plugin) {
     return {
         auth: settings.auth,
         validate: {
-            query: {
+            query: Joi.object.keys({
                 path: Joi.string()
-            }
+            })
         },
         handler: function (request, reply) {
 


### PR DESCRIPTION
Hello
Joi `4.7.0` to create a joi schema with `Joi.object().keys`

with 

```
validate: {
    query: {
        path: Joi.string()
    },
},
```

i have a error

```
{
  "statusCode": 400,
  "error": "Bad Request",
  "message": "path must be a string",
  "validation": {
    "source": "query",
    "keys": [
      "path"
    ]
  }
}
```
