### PR TITLE
update docs #server.pack.require to #server.pack.register

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ server.route([{
     your routes...
 }]);
 
-server.pack.require('lout', function() {
+server.pack.register(require('lout'), function() {
     server.start();
 });
 


### PR DESCRIPTION
I believe that method is of an earlier version.
maybe we should keep note?
