### PR TITLE
show route path in route view

### DIFF
--- a/templates/route.html
+++ b/templates/route.html
@@ -2,7 +2,7 @@
 <html lang="en">
 
 <head>
-    <title>Documentation for {{path}}</title>
+    <title>Documentation for {{#if this}}{{this.0.path}}{{/if}}</title>
     <link href="//netdna.bootstrapcdn.com/bootstrap/3.0.3/css/bootstrap.min.css" rel="stylesheet">
     <link href=".{{@cssBaseUrl}}/style.css" rel="stylesheet">
 </head>

--- a/test/index.js
+++ b/test/index.js
@@ -109,6 +109,7 @@ describe('Lout', function() {
 
             expect($('.badge').length).to.equal(2);
             expect($('h3.cors').length).to.equal(0);
+            expect($('title').text()).to.include('/test');
 
             done();
         });


### PR DESCRIPTION
An assumption being made here is that since the route view page shows routes filtered by path, it's safe to just display the first path in the title since they'll all be the same.
