### PR TITLE
Rework display to resemble JSON

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -227,11 +227,13 @@ internals.describe = function (params) {
     }
 
     var description = Joi.compile(params).describe();
-    return internals.getParamsData(description);
+    description = internals.getParamsData(description);
+    description.root = true;
+    return description;
 };
 
 
-internals.getParamsData = function (param, name) {
+internals.getParamsData = function (param, name, typeName) {
 
     // Detection of "false" as validation rule
     if (!name && param.type === 'object' && param.children && Object.keys(param.children).length === 0) {
@@ -247,10 +249,10 @@ internals.getParamsData = function (param, name) {
         return {
             condition: {
                 key: param.ref.substr(4), // removes 'ref:'
-                value: internals.getParamsData(param.is)
+                value: internals.getParamsData(param.is, undefined, param.is.type)
             },
-            then: param.then,
-            otherwise: param.otherwise
+            then: param.then && internals.getParamsData(param.then, undefined, param.then.type),
+            otherwise: param.otherwise && internals.getParamsData(param.otherwise, undefined, param.otherwise.type)
         };
     }
 
@@ -263,7 +265,8 @@ internals.getParamsData = function (param, name) {
     }
 
     var data = {
-        name: name,
+        typeIsName: !name && !!typeName,
+        name: name || typeName,
         description: param.description,
         notes: param.notes,
         tags: param.tags,
@@ -276,7 +279,7 @@ internals.getParamsData = function (param, name) {
         peers: param.dependencies && param.dependencies.map(internals.formatPeers),
         target: type === 'reference' ? internals.getExistsValues(type, param.valids) : null,
         flags: param.flags && {
-            allowUnknown: 'allowUnknown' in param.flags && param.flags.allowUnknown.toString(),
+            allowUnknown: param.flags.allowUnknown,
             default: param.flags.default,
             encoding: param.flags.encoding, // binary specific
             insensitive: param.flags.insensitive, // string specific
@@ -287,26 +290,37 @@ internals.getParamsData = function (param, name) {
     };
 
     if (data.type === 'object') {
+        var children = [];
+
         if (param.children) {
             var childrenKeys = Object.keys(param.children);
-            data.children = childrenKeys.map(function (key) {
+            children = children.concat(childrenKeys.map(function (key) {
 
                 return internals.getParamsData(param.children[key], key);
-            });
+            }));
         }
 
         if (param.patterns) {
-            data.patterns = param.patterns.map(function (pattern) {
+            children = children.concat(param.patterns.map(function (pattern) {
 
                 return internals.getParamsData(pattern.rule, pattern.regex);
-            });
+            }));
         }
+
+        data.children = children;
+    }
+
+    if (data.type === 'array' && param.items) {
+        data.items = param.items.map(function (item) {
+
+            return internals.getParamsData(item, undefined, item.type);
+        });
     }
 
     if (data.type === 'alternatives') {
         data.alternatives = param.alternatives.map(function (alternative) {
 
-            return internals.getParamsData(alternative);
+            return internals.getParamsData(alternative, undefined, alternative.type);
         });
     }
     else  {
@@ -318,15 +332,13 @@ internals.getParamsData = function (param, name) {
             });
         }
 
-        ['includes', 'excludes', 'items'].forEach(function (rule) {
-
-            if (param[rule]) {
-                data.rules[internals.capitalize(rule)] = param[rule].map(function (ruleType) {
-
-                    return internals.getParamsData(ruleType);
-                });
-            }
-        });
+        // If we have only one specific rule then set that to our type for
+        // brevity.
+        var rules = Object.keys(data.rules);
+        if (rules.length === 1 && !data.rules[rules[0]]) {
+            data.rules = {};
+            data.type = rules[0];
+        }
     }
 
     return data;
@@ -353,10 +365,10 @@ internals.getExistsValues = function (type, exists) {
             return (value.isContext ? '$' : '') + value.key;
         }
 
-        return value;
+        return JSON.stringify(value);
     });
 
-    return values.length ? values : null;
+    return values.length ? values.join(', ') : null;
 };
 
 

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -44,7 +44,7 @@ body {
 }
 .route-details .panel-body {
     padding-top: 0;
-    padding-bottom: 0;
+    padding-bottom: 15px;
 }
 .route-details .panel-heading {
     padding-top: 5px;
@@ -70,10 +70,35 @@ body {
 .route-details .panel-heading.OPTIONS {
     background-color: #DEF2F8;
 }
-.route-details .type {
-    background-color: rgba(0, 0, 0, 0.03);
-    padding: 5px;
+
+.auth-header,
+.auth-value,
+.cors-header,
+.cors-single-value {
+    float: left;
+    margin: 0;
+    padding: 0;
+    font-size: inherit;
+    line-height: inherit;
 }
+.auth-header,
+.cors-header {
+    clear: left;
+    font-size: inherit;
+    font-weight: bold;
+    padding-right: 0.5em;
+}
+.cors-multi-value {
+    clear: left;
+}
+.cors-multi-value > ul {
+    margin-bottom: 0;
+}
+
+.conditional {
+    margin-bottom: 15px;
+}
+
 .conditional .consequence-text {
     font-weight: bold;
 }
@@ -88,3 +113,74 @@ body {
 .reference {
     font-style: italic;
 }
+
+.route-details .type {
+    padding: 0;
+    margin: 0;
+}
+
+.type-header:hover ~ .token-open,
+.type-header:hover ~ .token-close,
+.token-open:hover,
+.token-open:hover ~ .token-close {
+    font-weight: bold;
+}
+
+.list-children,
+.list-items {
+    padding-left: 1em;
+}
+.list-children:empty,
+.list-items:empty {
+    display: none;
+}
+
+.well {
+    overflow: auto;
+    clear: both;
+}
+
+.well dt {
+    clear: both;
+    float: left;
+}
+.well dd {
+    float: left;
+}
+
+.well pre {
+    background-color: #fff;
+}
+
+.type-header {
+    display: inline;
+    font-size: 14px;
+}
+.type-header > h5 {
+    display: inline;
+    font-size: inherit;
+}
+
+.field-type {
+    padding-right: 0.5em;
+}
+.field-type:before {
+    content: ":";
+    padding-right: 0.5em;
+}
+.field-type:first-child:before {
+    content: "";
+}
+.field-type:empty {
+    padding-right: 0;
+}
+
+.field-type-rule {
+    font-weight: bold;
+}
+
+dt.field-example,
+dt.field-meta {
+    float: none;
+}
+

--- a/templates/helpers/collapse.js
+++ b/templates/helpers/collapse.js
@@ -1,0 +1,39 @@
+'use strict';
+
+var Handlebars = require('handlebars');
+
+var uniqueId = 0;
+
+module.exports = function (options) {
+
+    var data = Handlebars.createFrame(options.data);
+    data.collapseId = uniqueId++;
+
+    var children = options.fn.partials.children(this).trim(),
+        content = options.fn(this).trim();
+    if (content) {
+        data.static = false;
+
+        var header = options.fn.partials.header(this, { data: data }).trim();
+        if (/data-toggle="collapse"/.test(header)) {
+            content = header
+                + '<div class="collapse" id="type' + data.collapseId + '">'
+                    + '<dl class="well">'
+                        + content
+                    + '</dl>'
+                + '</div>';
+        } else {
+            content = header
+                + '<div class="static-type">'
+                    + '<dl class="well">'
+                        + content
+                    + '</dl>'
+                + '</div>';
+        }
+    } else {
+        data.static = true;
+        content = options.fn.partials.header(this, { data: data });
+    }
+
+    return new Handlebars.SafeString(content + children);
+};

--- a/templates/helpers/exists.js
+++ b/templates/helpers/exists.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = function (value) {
+
+    return !!value;
+};

--- a/templates/helpers/type.js
+++ b/templates/helpers/type.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var Handlebars = require('handlebars');
+
+module.exports = function () {
+
+    var type = this.type;
+    if (type === 'object'
+        || (type === 'array' && this.items)) {
+        type = '';
+    }
+
+    if (this.typeIsName || this.root) {
+        return new Handlebars.SafeString('<span>&nbsp;</span>');
+    }
+
+    return new Handlebars.SafeString('<span class="field-type">' + type + '</span>');
+};

--- a/templates/route.html
+++ b/templates/route.html
@@ -55,21 +55,21 @@
                 {{/if}} {{#if this.auth}}
                 <h3>Authentication</h3>
                 <p class="auth">
-                    <h4 class="auth-strategies">Strategies</h4>
-                    <p class="auth-strategies">{{this.auth.strategies}}</p>
-                    <h4 class="auth-mode">Mode</h4>
-                    <p class="auth-mode">{{this.auth.mode}}</p>
-                    <h4 class="auth-payload">Payload</h4>
-                    <p class="auth-payload">{{this.auth.payload}}</p>
+                    <h4 class="auth-header auth-strategies col-sm-2">Strategies</h4>
+                    <p class="auth-value auth-strategies">{{this.auth.strategies}}</p>
+                    <h4 class="auth-header auth-mode col-sm-2">Mode</h4>
+                    <p class="auth-value auth-mode">{{this.auth.mode}}</p>
+                    <h4 class="auth-header auth-payload col-sm-2">Payload</h4>
+                    <p class="auth-value auth-payload">{{this.auth.payload}}</p>
                     {{#if this.auth.scope}}
-                    <h4 class="auth-scope">Scope</h4>
-                    <p class="auth-scope">{{this.auth.scope}}</p>
+                    <h4 class="auth-header auth-scope col-sm-2">Scope</h4>
+                    <p class="auth-value auth-scope">{{this.auth.scope}}</p>
                     {{/if}} {{#if this.auth.entity}}
-                    <h4 class="auth-entity">Entity</h4>
-                    <p class="auth-entity">{{this.auth.entity}}</p>
+                    <h4 class="auth-header auth-entity col-sm-2">Entity</h4>
+                    <p class="auth-value auth-entity">{{this.auth.entity}}</p>
                     {{/if}} {{#if this.auth.tos}}
-                    <h4 class="auth-tos">Terms of service</h4>
-                    <p class="auth-tos">{{this.auth.tos}}</p>
+                    <h4 class="auth-header auth-tos col-sm-2">Terms of service</h4>
+                    <p class="auth-value auth-tos">{{this.auth.tos}}</p>
                     {{/if}}
                 </p>
                 {{/if}} {{#if this.vhost}}
@@ -78,19 +78,19 @@
                 {{/if}} {{#if this.cors}}
                 <h3 class="cors">CORS</h3>
                 <dl>
-                    <dt class="cors-origin">Origin</dt>
-                    <dd class="cors-origin">
+                    <dt class="cors-header cors-origin">Origin</dt>
+                    <dd class="cors-multi-value cors-origin">
                         <ul>
                             {{#each this.cors.origin}}
                                 <li>{{this}}</li>
                             {{/each}}
                         </ul>
                     </dd>
-                    <dt class="cors-maxAge">maxAge</dt>
-                    <dd class="cors-maxAge">{{this.cors.maxAge}}</dd>
+                    <dt class="cors-header cors-maxAge">maxAge</dt>
+                    <dd class="cors-value cors-maxAge">{{this.cors.maxAge}}</dd>
                     {{#if this.cors.headers}}
-                        <dt class="cors-headers">headers</dt>
-                        <dd class="cors-headers">
+                        <dt class="cors-header cors-headers">headers</dt>
+                        <dd class="cors-multi-value cors-headers">
                             <ul>
                                 {{#each this.cors.headers}}
                                 <li>{{this}}</li>
@@ -98,8 +98,8 @@
                             </ul>
                         </dd>
                     {{/if}} {{#if this.cors.additionalHeaders}}
-                        <dt class="cors-additionalHeaders">additionalHeaders</dt>
-                        <dd class="cors-additionalHeaders">
+                        <dt class="cors-header cors-additionalHeaders">additionalHeaders</dt>
+                        <dd class="cors-multi-value cors-additionalHeaders">
                             <ul>
                                 {{#each this.cors.additionalHeaders}}
                                 <li>{{this}}</li>
@@ -107,8 +107,8 @@
                             </ul>
                         </dd>
                     {{/if}} {{#if this.cors.methods}}
-                        <dt class="cors-methods">methods</dt>
-                        <dd class="cors-methods">
+                        <dt class="cors-header cors-methods">methods</dt>
+                        <dd class="cors-multi-value cors-methods">
                             <ul>
                                 {{#each this.cors.methods}}
                                 <li>{{this}}</li>
@@ -116,8 +116,8 @@
                             </ul>
                         </dd>
                     {{/if}} {{#if this.cors.additionalMethods}}
-                        <dt class="cors-additionalMethods">additionalMethods</dt>
-                        <dd class="cors-additionalMethods">
+                        <dt class="cors-header cors-additionalMethods">additionalMethods</dt>
+                        <dd class="cors-multi-value cors-additionalMethods">
                             <ul>
                                 {{#each this.cors.additionalMethods}}
                                 <li>{{this}}</li>
@@ -125,8 +125,8 @@
                             </ul>
                         </dd>
                     {{/if}} {{#if this.cors.exposedHeaders}}
-                        <dt class="cors-exposedHeaders">exposedHeaders</dt>
-                        <dd class="cors-exposedHeaders">
+                        <dt class="cors-header cors-exposedHeaders">exposedHeaders</dt>
+                        <dd class="cors-multi-value cors-exposedHeaders">
                             <ul>
                                 {{#each this.cors.exposedHeaders}}
                                 <li>{{this}}</li>
@@ -134,10 +134,10 @@
                             </ul>
                         </dd>
                     {{/if}}
-                    <dt class="cors-credentials">credentials</dt>
-                    <dd class="cors-credentials">{{this.cors.credentials}}</dd>
-                    <dt class="cors-override">override</dt>
-                    <dd class="cors-override">{{this.cors.override}}</dd>
+                    <dt class="cors-header cors-credentials">credentials</dt>
+                    <dd class="cors-value cors-credentials">{{this.cors.credentials}}</dd>
+                    <dt class="cors-header cors-override">override</dt>
+                    <dd class="cors-value cors-override">{{this.cors.override}}</dd>
                 </dl>
                 {{/if}} {{#if this.jsonp}}
                 <h3 class="jsonp">JSONP</h3>
@@ -210,6 +210,8 @@
         </div>
         {{/each}}
     </div>
-</body>
 
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+    <script src="//netdna.bootstrapcdn.com/bootstrap/3.0.3/js/bootstrap.min.js"></script>
+</body>
 </html>

--- a/templates/type-header.html
+++ b/templates/type-header.html
@@ -1,0 +1,36 @@
+{{#if this.type}}
+    <div class="type-header">
+        {{#if this.name }}
+            <h5>
+                {{#if @static}}
+                    {{~ this.name ~}}
+                {{~else~}}
+                    <a role="button" data-toggle="collapse" href="#type{{@collapseId}}" aria-expanded="false" aria-controls="type{{@collapseId}}">
+                        {{~ this.name ~}}
+                    </a>
+                {{~/ if ~}}
+            </h5>
+        {{~/ if ~}}
+
+        {{~ type ~}}
+        {{#if this.flags.required}}
+            <i class="glyphicon glyphicon-star" title="This is a required field."></i>
+        {{/if}}
+        {{#if this.flags.forbidden}}
+            <i class="glyphicon glyphicon-minus-sign" title="This is a forbidden field."></i>
+        {{~/if~}}
+        {{#if this.flags.stripped}}
+            <i class="glyphicon glyphicon-trash" title="This field will be removed."></i>
+        {{~/if~}}
+
+        <div class="pull-right">
+            {{~#if this.flags.allowUnknown}}
+                <div class="badge allow-unknown">Allow unknown keys</div>
+            {{~/if~}}
+            {{#if this.flags.insensitive}}
+                <div class="badge case-insensitive">Case insensitive</div>
+            {{~/if~}}
+        </div>
+        {{~! Strip Whitespace ~}}
+    </div>
+{{~/if~}}

--- a/templates/type.html
+++ b/templates/type.html
@@ -1,44 +1,53 @@
-<li>
+<li class="{{#if this.condition}}conditional{{else}}type{{/if}}">
     {{#if this.condition}}
-        <div class="conditional">
             <span class="condition">
                 <span class="condition-text">
                     <span>If</span>
                     <span class="condition-key">{{this.condition.key}}</span>
                     <span>matches the following model :</span>
                 </span>
-                <ul class="list-unstyled condition-model">{{> type this.condition.value}}</ul>
+                <ul class="list-unstyled list-children condition-model">{{> type this.condition.value}}</ul>
             </span>
             <span class="consequence">
                 <span class="consequence-text">Then :</span>
-                <ul class="list-unstyled consequence-model">{{> type this.then}}</ul>
+                <ul class="list-unstyled list-children consequence-model">{{> type this.then}}</ul>
             </span>
             <span class="consequence">
                 <span class="consequence-text">Otherwise :</span>
-                <ul class="list-unstyled consequence-model">{{> type this.otherwise}}</ul>
+                <ul class="list-unstyled list-children consequence-model">{{> type this.otherwise}}</ul>
             </span>
-        </div>
     {{else}}
-        <dl class="type">
-            <h5>
-                <em>{{this.name}}</em>
-                {{#if this.flags.required}}
-                    <i class="glyphicon glyphicon-star" title="This is a required field."></i>
+        {{#collapse}}
+            {{#*inline "header"}}
+                {{> type-header ~}}
+            {{/inline}}
+            {{#*inline "children"}}
+                {{~#if (exists this.children) ~}}
+                    <span class="token-open">{</span>
+                    <ul class="list-unstyled list-children">
+                        {{~#each this.children}}{{> type}}{{/each~}}
+                    </ul>
+                    <span class="token-close">}</span>
+                {{~/if~}}
+                {{~#if (exists this.items) ~}}
+                    <span class="token-open">[</span
+                    <ul class="list-unstyled list-items">
+                        {{~#each this.items}}{{> type}}{{/each~}}
+                    </ul>
+                    <span class="token-close">]</span>
+                {{~/if~}}
+                {{#if this.alternatives}}
+                    <span class="token-open">(</span>
+                    <ul class="list-unstyled list-children field-alternatives">
+                        {{#each this.alternatives}}{{> type}}{{/each}}
+                    </ul>
+                    <span class="token-close">)</span>
                 {{/if}}
-                {{#if this.flags.forbidden}}
-                    <i class="glyphicon glyphicon-minus-sign" title="This is a forbidden field."></i>
-                {{/if}}
-                {{#if this.flags.stripped}}
-                    <i class="glyphicon glyphicon-trash" title="This field will be removed."></i>
-                {{/if}}
-            </h5>
+            {{/inline}}
+
             {{#if this.description}}
                 <p>{{this.description}}</p>
             {{/if}}
-            <dt>
-                <h6>Type</h6>
-            </dt>
-            <dd>{{this.type}}</dd>
             {{#if this.target}}
                 <dt class="ref-target">Target</dt>
                 <dd class="ref-target">{{this.target}}</dd>
@@ -51,43 +60,15 @@
                 <dt class="encoding">Encoding</dt>
                 <dd class="encoding">{{this.flags.encoding}}</dd>
             {{/if}}
-            {{#if this.flags.default}}
-                <dt class="default-value">Default value</dt>
-                <dd class="default-value">
-                    <pre><code>{{json this.flags.default}}</code></pre>
-                </dd>
-            {{/if}}
-            {{#if this.notes}}
-                <dt>Notes</dt>
-                <dd>{{{this.notes}}}</dd>
-            {{/if}}
-            {{#if this.meta}}
-                <dt>Meta</dt>
-                <dd>
-                    <p class="meta">
-                        <pre><code>{{json this.meta}}</code></pre>
-                    </p>
-                </dd>
-            {{/if}}
-            {{#if this.examples}}
-                <dt>Examples</dt>
-                {{#each this.examples}}
-                    <dd class="example">
-                        <pre><code>{{json this}}</code></pre>
-                    </dd>
-                {{/each}}
-            {{/if}}
             {{#if this.allowedValues}}
-                <dt>Allowed Values</dt>
-                {{#each this.allowedValues}}
-                    <dd>{{this}}</dd>
-                {{/each}}
+                <dt class="field-allowed-values">one of</dt>
+                {{~! Strip Whitespace ~}}
+                <dd class="field-allowed-values">{{this.allowedValues}}</dd>
             {{/if}}
             {{#if this.disallowedValues}}
-                <dt>Forbidden Values</dt>
-                {{#each this.disallowedValues}}
-                    <dd>{{this}}</dd>
-                {{/each}}
+                <dt class="field-forbidden-values">none of</dt>
+                {{~! Strip Whitespace ~}}
+                <dd class="field-forbidden-values">{{this.disallowedValues}}</dd>
             {{/if}}
             {{#if this.peers}}
                 <dt class="peers-conditions">Peers conditions</dt>
@@ -96,40 +77,6 @@
                         {{#each this.peers}}
                             <li class="peer-condition">{{this}}</li>
                         {{/each}}
-                    </ul>
-                </dd>
-            {{/if}}
-            {{#if this.patterns}}
-                <dt class="patterns">Patterns</dt>
-                <dd class="patterns">
-                    <ul class="list-unstyled">
-                        {{#each this.patterns}}
-                            {{> type}}
-                        {{/each}}
-                    </ul>
-                </dd>
-            {{/if}}
-            {{#if this.flags.allowUnknown}}
-                <dt class="allow-unknown">Allow unknown keys</dt>
-                <dd class="allow-unknown">{{this.flags.allowUnknown}}</dd>
-            {{/if}}
-            {{#if this.flags.insensitive}}
-                <dt class="case-insensitive">Case insensitive matching</dt>
-                <dd class="case-insensitive">true</dd>
-            {{/if}}
-            {{#if this.children}}
-                <dt>Properties</dt>
-                <dd>
-                    <ul class="list-unstyled">
-                        {{#each this.children}}{{> type}}{{/each}}
-                    </ul>
-                </dd>
-            {{/if}}
-            {{#if this.alternatives}}
-                <dt>Alternatives</dt>
-                <dd>
-                    <ul class="list-unstyled">
-                        {{#each this.alternatives}}{{> type}}{{/each}}
                     </ul>
                 </dd>
             {{/if}}
@@ -160,6 +107,29 @@
                 </dd>
                 {{/if}}
             {{/each}}
-        </dl>
+
+            {{#if this.notes}}
+                <dt>Notes</dt>
+                <dd>{{{this.notes}}}</dd>
+            {{/if}}
+            {{#if this.flags.default}}
+                <dt class="default-value">Default value</dt>
+                <dd class="default-value">{{json this.flags.default}}</dd>
+            {{/if}}
+            {{#if this.meta}}
+                <dt class="field-meta">Meta</dt>
+                <dd class="field-meta">
+                    <pre><code>{{json this.meta}}</code></pre>
+                </dd>
+            {{/if}}
+            {{#if this.examples}}
+                <dt class="field-example">Examples</dt>
+                {{#each this.examples}}
+                    <dd class="example">
+                        <pre><code>{{json this}}</code></pre>
+                    </dd>
+                {{/each}}
+            {{/if}}
+        {{/collapse}}
     {{/if}}
 </li>

--- a/test/index.js
+++ b/test/index.js
@@ -153,7 +153,7 @@ describe('Lout', function () {
                 expect($(this).text().replace(/\n|\s+/g, '')).to.contain(matches.shift());
             });
 
-            expect($('.badge').length).to.equal(2);
+            expect($('.badge').length).to.equal(3);
             expect($('h3.cors').length).to.equal(0);
             expect($('title').text()).to.include('/test');
 
@@ -167,7 +167,7 @@ describe('Lout', function () {
 
             var $ = Cheerio.load(res.result);
 
-            expect($('dt h6').length).to.equal(5);
+            expect($('.type-header').length).to.equal(5);
 
             done();
         });
@@ -177,7 +177,7 @@ describe('Lout', function () {
 
         server.inject('/docs?server=http://test&path=/alternatives', function (res) {
 
-            expect(res.result).to.contain('Alternatives');
+            expect(res.result).to.contain('field-alternatives');
             expect(res.result).to.contain('number');
             expect(res.result).to.contain('string');
             expect(res.result).to.contain('first');
@@ -260,7 +260,7 @@ describe('Lout', function () {
         server.inject('/docs?server=http://test&path=/emptyobject', function (res) {
 
             expect(res.result).to.contain('param1');
-            expect(res.result.match(/Properties/g)).to.have.length(1);
+            expect(res.result.match(/list-children/g)).to.have.length(2);
             done();
         });
     });
@@ -337,7 +337,7 @@ describe('Lout', function () {
         server.inject('/docs?server=http://test&path=/withmeta', function (res) {
 
             var $ = Cheerio.load(res.result);
-            expect($('.meta pre code').length).to.equal(1);
+            expect($('.field-meta pre code').length).to.equal(1);
             done();
         });
     });
@@ -412,7 +412,6 @@ describe('Lout', function () {
 
         server.inject('/docs?server=http://test&path=/withpattern', function (res) {
 
-            expect(res.result).to.contain('Patterns');
             expect(res.result).to.contain('/\\w\\d/');
             expect(res.result).to.contain('boolean');
             done();
@@ -424,7 +423,7 @@ describe('Lout', function () {
         server.inject('/docs?server=http://test&path=/withallowunknown', function (res) {
 
             var $ = Cheerio.load(res.result);
-            expect($('dd.allow-unknown').text()).to.equal('truefalse');
+            expect($('.allow-unknown').length).to.equal(1);
             done();
         });
     });
@@ -434,7 +433,7 @@ describe('Lout', function () {
         server.inject('/docs?server=http://test&path=/test', function (res) {
 
             var $ = Cheerio.load(res.result);
-            expect($('dd.case-insensitive').length).to.equal(1);
+            expect($('.case-insensitive').length).to.equal(1);
             done();
         });
     });
@@ -463,9 +462,9 @@ describe('Lout', function () {
             expect($('.condition-text').text().replace(/\n|\s+/g, ''))
                 .to.contain('Ifbmatchesthefollowingmodel')
                 .to.contain('Ifamatchesthefollowingmodel');
-            expect($('.condition-model').length).to.equal(2);
-            expect($('.consequence-model').length).to.equal(4);
-            expect($('.type > dd').text())
+            expect($('.condition-model').length).to.equal(4);
+            expect($('.consequence-model').length).to.equal(8);
+            expect($('.field-alternatives .type-header').text())
                 .to.contain('string')
                 .to.contain('number')
                 .to.contain('boolean')

--- a/test/routes/default.js
+++ b/test/routes/default.js
@@ -103,7 +103,8 @@ module.exports = [{
         validate: {
             query: {
                 param1: Joi.object({
-                    nestedparam1: Joi.string().required()
+                    nestedparam1: Joi.string().required(),
+                    array: Joi.array()
                 })
             }
         }
@@ -162,6 +163,38 @@ module.exports = [{
         validate: {
             query: {
                 param1: Joi.alternatives().try(Joi.number().required(), Joi.string().valid('first', 'last'))
+            }
+        }
+    }
+}, {
+    method: 'GET',
+    path: '/withnestedalternatives',
+    config: {
+        handler: handler,
+        validate: {
+            query: {
+                param1: Joi.object({
+                    param2: Joi.alternatives().try(
+                        {
+                            param3: Joi.object({
+                                param4: Joi.number().example(5)
+                            }).description('this is cool too')
+                        },
+                        Joi.number().min(42)
+                    )
+                }).description('something really cool'),
+                param2: Joi.array().items(
+                    Joi.object({
+                        param2: Joi.alternatives().try(
+                            {
+                                param3: Joi.object({
+                                    param4: Joi.number().example(5)
+                                }).description('this is cool too')
+                            },
+                            Joi.number().min(42).required()
+                        )
+                    }).description('all the way down')
+                ).description('something really cool')
             }
         }
     }
@@ -389,7 +422,8 @@ module.exports = [{
                     .hostname()
                     .lowercase()
                     .uppercase()
-                    .trim()
+                    .trim(),
+                param2: Joi.string().email()
             }
         }
     }
@@ -404,11 +438,20 @@ module.exports = [{
                     .when('b', {
                         is: 5,
                         then: Joi.string(),
-                        otherwise: Joi.number()
+                        otherwise: Joi.number().required().description('Things and stuff')
                     })
                     .when('a', {
                         is: true,
                         then: Joi.date(),
+                        otherwise: Joi.any()
+                    }),
+                param2: Joi.alternatives()
+                    .when('b', {
+                        is: 5,
+                        then: Joi.string()
+                    })
+                    .when('a', {
+                        is: true,
                         otherwise: Joi.any()
                     })
             }


### PR DESCRIPTION
Mimic JSON structures with {key: type} and [type] structures. Extended validation data is pushed into collapsible sections to simplify the UI structure.

Additionally reduces the vertical height of the UI where possible to help with UI cohesion.

Preview of behavior with these changes (slightly older format):
![lout](https://cloud.githubusercontent.com/assets/196390/10255027/16fdaaf2-690d-11e5-8d5f-f220a0ad9492.gif)

Continuation of some of the discussion in #120
