### PR TITLE
Attempt to make alternatives UI clearer

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -313,14 +313,14 @@ internals.getParamsData = function (param, name, typeName) {
     if (data.type === 'array' && param.items) {
         data.items = param.items.map(function (item) {
 
-            return internals.getParamsData(item, undefined, item.type);
+            return internals.getParamsData(item);
         });
     }
 
     if (data.type === 'alternatives') {
         data.alternatives = param.alternatives.map(function (alternative) {
 
-            return internals.getParamsData(alternative, undefined, alternative.type);
+            return internals.getParamsData(alternative);
         });
     }
     else  {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -119,8 +119,34 @@ body {
     margin: 0;
 }
 
+.type-header {
+    display: inline;
+    font-size: 14px;
+}
+.type-header > h5 {
+    display: inline;
+    font-size: inherit;
+}
+.type-header > h5 > a {
+    color: inherit;
+    text-decoration: none;
+}
+.type-header > h5 > a:hover,
+.type-header > h5 > a:hover {
+    text-decoration: none;
+}
+
+.more-info {
+    padding-right: 5em;
+}
+
+.type-header:hover .more-info {
+    text-decoration: underline;
+}
 .type-header:hover ~ .token-open,
 .type-header:hover ~ .token-close,
+.token-before-open:hover ~ .token-open,
+.token-before-open:hover ~ .token-close,
 .token-open:hover,
 .token-open:hover ~ .token-close {
     font-weight: bold;
@@ -152,13 +178,13 @@ body {
     background-color: #fff;
 }
 
-.type-header {
-    display: inline;
-    font-size: 14px;
+.field-alternatives > .type-alternatives,
+.field-alternatives > .type-array,
+.field-alternatives > .type-object {
+    padding-bottom: 1em;
 }
-.type-header > h5 {
-    display: inline;
-    font-size: inherit;
+.field-alternatives > .type:last-of-type {
+    padding-bottom: 0;
 }
 
 .field-type {
@@ -170,6 +196,7 @@ body {
 }
 .field-type:first-child:before {
     content: "";
+    padding-right: 0;
 }
 .field-type:empty {
     padding-right: 0;

--- a/templates/helpers/collapse.js
+++ b/templates/helpers/collapse.js
@@ -15,21 +15,12 @@ module.exports = function (options) {
         data.static = false;
 
         var header = options.fn.partials.header(this, { data: data }).trim();
-        if (/data-toggle="collapse"/.test(header)) {
-            content = header
-                + '<div class="collapse" id="type' + data.collapseId + '">'
-                    + '<dl class="well">'
-                        + content
-                    + '</dl>'
-                + '</div>';
-        } else {
-            content = header
-                + '<div class="static-type">'
-                    + '<dl class="well">'
-                        + content
-                    + '</dl>'
-                + '</div>';
-        }
+        content = header
+            + '<div class="collapse" id="type' + data.collapseId + '">'
+                + '<dl class="well">'
+                    + content
+                + '</dl>'
+            + '</div>';
     } else {
         data.static = true;
         content = options.fn.partials.header(this, { data: data });

--- a/templates/helpers/type.js
+++ b/templates/helpers/type.js
@@ -6,6 +6,7 @@ module.exports = function () {
 
     var type = this.type;
     if (type === 'object'
+        || type === 'alternatives'
         || (type === 'array' && this.items)) {
         type = '';
     }

--- a/templates/type-header.html
+++ b/templates/type-header.html
@@ -30,6 +30,15 @@
             {{#if this.flags.insensitive}}
                 <div class="badge case-insensitive">Case insensitive</div>
             {{~/if~}}
+            {{#unless @static }}
+                <a class="more-info"
+                    role="button"
+                    data-toggle="collapse"
+                    href="#type{{@collapseId}}"
+                    aria-expanded="false"
+                    aria-controls="type{{@collapseId}}"
+                >Info</a>
+            {{/unless}}
         </div>
         {{~! Strip Whitespace ~}}
     </div>

--- a/templates/type-header.html
+++ b/templates/type-header.html
@@ -37,7 +37,7 @@
                     href="#type{{@collapseId}}"
                     aria-expanded="false"
                     aria-controls="type{{@collapseId}}"
-                >Info</a>
+                >Details</a>
             {{/unless}}
         </div>
         {{~! Strip Whitespace ~}}

--- a/templates/type.html
+++ b/templates/type.html
@@ -30,7 +30,7 @@
                     <span class="token-close">}</span>
                 {{~/if~}}
                 {{~#if (exists this.items) ~}}
-                    <span class="token-open">[</span
+                    <span class="token-open">[</span>
                     <ul class="list-unstyled list-items">
                         {{~#each this.items}}{{> type}}{{/each~}}
                     </ul>

--- a/templates/type.html
+++ b/templates/type.html
@@ -1,4 +1,4 @@
-<li class="{{#if this.condition}}conditional{{else}}type{{/if}}">
+<li class="{{#if this.condition}}conditional{{else}}type type-{{this.type}}{{/if}}">
     {{#if this.condition}}
             <span class="condition">
                 <span class="condition-text">
@@ -37,7 +37,7 @@
                     <span class="token-close">]</span>
                 {{~/if~}}
                 {{#if this.alternatives}}
-                    <span class="token-open">(</span>
+                    <span class="token-before-open">Any of </span><span class="token-open">(</span>
                     <ul class="list-unstyled list-children field-alternatives">
                         {{#each this.alternatives}}{{> type}}{{/each}}
                     </ul>

--- a/test/routes/default.js
+++ b/test/routes/default.js
@@ -191,7 +191,9 @@ module.exports = [{
                                     param4: Joi.number().example(5)
                                 }).description('this is cool too')
                             },
-                            Joi.number().min(42).required()
+                            Joi.array().items('foo', 'bar'),
+                            Joi.number().min(42).required(),
+                            Joi.number().max(42).required()
                         )
                     }).description('all the way down')
                 ).description('something really cool')


### PR DESCRIPTION
Got some feedback from my client guys on the new UI and they had some confusion on the alternatives UI. This attempts to clear that up.
- Add info button to collapse section so we always have something to display without needing awkward “object” and “array” prefixes.
- Remove type prefixes for nested objects
- Add padding for visual separation
- Add “Any of” prefix to make alternatives options clearer
- Remove static well

As a consequence of the info changes, we now have uniform handling for the well content across both root sections and nested UIs.

![image](https://cloud.githubusercontent.com/assets/196390/10712002/5eb4c69a-7a52-11e5-9298-fe3bcfb68b2a.png)
