### PR TITLE
Add support for config.response.status schemas

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -214,7 +214,8 @@ internals.getRoutesData = function (routes) {
             pathParams: internals.describe(route.settings.validate.params),
             queryParams: internals.describe(route.settings.validate.query),
             payloadParams: internals.describe(route.settings.validate.payload),
-            responseParams: internals.describe(route.settings.response.schema)
+            responseParams: internals.describe(route.settings.response.schema),
+            statusSchema: internals.describeStatusSchema(route.settings.response.status)
         };
     });
 };
@@ -230,6 +231,21 @@ internals.describe = function (params) {
     description = internals.getParamsData(description);
     description.root = true;
     return description;
+};
+
+internals.describeStatusSchema = function (status) {
+
+    var codes = Object.keys(status || {});
+    if (!codes.length) {
+        return;
+    }
+
+    var result = {};
+    codes.forEach(function (code) {
+
+        result[code] = internals.describe(status[code]);
+    });
+    return result;
 };
 
 

--- a/templates/route.html
+++ b/templates/route.html
@@ -206,11 +206,11 @@
                         {{/if}}
                         {{#if this.statusSchema}}
                             <h3>
-                                <a role="button" data-toggle="collapse" href="#statusCode" aria-expanded="false" aria-controls="statusCode">
+                                <a role="button" data-toggle="collapse" href="#statusCode{{this.method}}" aria-expanded="false" aria-controls="statusCode{{this.method}}">
                                     Status Code Responses
                                 </a>
                             </h3>
-                            <div class="collapse" id="statusCode">
+                            <div class="collapse" id="statusCode{{this.method}}">
                                 {{#each this.statusSchema as |schema code|}}
                                 <dt>
                                     <h4>{{code}}</h4>

--- a/templates/route.html
+++ b/templates/route.html
@@ -204,6 +204,29 @@
                             {{/if}}
                         </dd>
                         {{/if}}
+                        {{#if this.statusSchema}}
+                            <h3>
+                                <a role="button" data-toggle="collapse" href="#statusCode" aria-expanded="false" aria-controls="statusCode">
+                                    Status Code Responses
+                                </a>
+                            </h3>
+                            <div class="collapse" id="statusCode">
+                                {{#each this.statusSchema as |schema code|}}
+                                <dt>
+                                    <h4>{{code}}</h4>
+                                </dt>
+                                <dd>
+                                    {{#if schema.isDenied}}
+                                    <h5>Denied</h5>
+                                    {{else}}
+                                    <ul class="list-unstyled">
+                                        {{> type schema}}
+                                    </ul>
+                                    {{/if}}
+                                </dd>
+                                {{/each}}
+                            </div>
+                        {{/if}}
                     </dl>
                 </li>
             </ul>

--- a/test/index.js
+++ b/test/index.js
@@ -557,6 +557,22 @@ describe('Lout', function () {
         });
     });
 
+
+    it('should support status schema', function (done) {
+
+        server.inject('/docs?server=http://test&path=/withstatus', function (res) {
+
+            var $ = Cheerio.load(res.result);
+            expect($('.collapse').text())
+                .to.contain('204')
+                .to.contain('param2')
+                .to.contain('404')
+                .to.contain('Failure');
+            done();
+        });
+    });
+
+
     describe('Authentication', function () {
 
         before(function (done) {

--- a/test/routes/default.js
+++ b/test/routes/default.js
@@ -217,6 +217,25 @@ module.exports = [{
     }
 }, {
     method: 'GET',
+    path: '/withstatus',
+    config: {
+        handler: handler,
+        response: {
+            schema: {
+                param1: Joi.string()
+            },
+            status: {
+                204: {
+                    param2: Joi.string()
+                },
+                404: {
+                    error: 'Failure'
+                }
+            }
+        }
+    }
+}, {
+    method: 'GET',
     path: '/withpojoinarray',
     config: {
         handler: handler,


### PR DESCRIPTION
Creates a drawer to show content for status specific schemas when they exist.

![image](https://cloud.githubusercontent.com/assets/196390/10712284/b6267f14-7a5b-11e5-9765-a6fd7aa6799a.png)

![image](https://cloud.githubusercontent.com/assets/196390/10712285/bd793af4-7a5b-11e5-84fe-541259e8348a.png)

Partial fix for #128 
