### PR TITLE
Handle notes array objects

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -205,7 +205,7 @@ internals.getRoutesData = function (routes) {
             path: route.path,
             method: route.method.toUpperCase(),
             description: route.settings.description,
-            notes: route.settings.notes,
+            notes: internals.processNotes(route.settings.notes),
             tags: route.settings.tags,
             auth: route.settings.auth,
             vhost: route.settings.vhost,
@@ -268,7 +268,7 @@ internals.getParamsData = function (param, name, typeName) {
         typeIsName: !name && !!typeName,
         name: name || typeName,
         description: param.description,
-        notes: param.notes,
+        notes: internals.processNotes(param.notes),
         tags: param.tags,
         meta: param.meta,
         unit: param.unit,
@@ -413,4 +413,17 @@ internals.processRuleArgument = function (rule) {
     }
 
     return arg || '';
+};
+
+internals.processNotes = function (notes) {
+
+    if (!notes) {
+        return;
+    }
+
+    if (!Array.isArray(notes)) {
+        return [notes];
+    }
+
+    return notes;
 };

--- a/templates/route.html
+++ b/templates/route.html
@@ -51,7 +51,11 @@
                 <p class="description">{{{this.description}}}</p>
                 {{/if}} {{#if this.notes}}
                 <h3>Notes</h3>
-                <p class="notes">{{{this.notes}}}</p>
+                <ul class="list-unstyled list-notes">
+                    {{#each this.notes}}
+                        <li>{{{this}}}</li>
+                    {{/each}}
+                </ul>
                 {{/if}} {{#if this.auth}}
                 <h3>Authentication</h3>
                 <p class="auth">

--- a/templates/type.html
+++ b/templates/type.html
@@ -110,7 +110,13 @@
 
             {{#if this.notes}}
                 <dt>Notes</dt>
-                <dd>{{{this.notes}}}</dd>
+                <dd>
+                    <ul class="list-unstyled list-notes">
+                        {{#each this.notes}}
+                            <li>{{{this}}}</li>
+                        {{/each}}
+                    </ul>
+                </dd>
             {{/if}}
             {{#if this.flags.default}}
                 <dt class="default-value">Default value</dt>

--- a/test/index.js
+++ b/test/index.js
@@ -294,6 +294,16 @@ describe('Lout', function () {
         });
     });
 
+    it('should show note arrays', function (done) {
+
+        server.inject('/docs?server=http://test&path=/withnotesarray', function (res) {
+
+            var $ = Cheerio.load(res.result);
+            expect($('.htmltypenote').length).to.equal(2);
+            done();
+        });
+    });
+
     it('should show example', function (done) {
 
         server.inject('/docs?server=http://test&path=/withexample', function (res) {

--- a/test/routes/default.js
+++ b/test/routes/default.js
@@ -257,6 +257,20 @@ module.exports = [{
     }
 }, {
     method: 'GET',
+    path: '/withnotesarray',
+    config: {
+        handler: handler,
+        validate: {
+            query: {
+                param1: Joi.string().notes([
+                    '<span class="htmltypenote">HTML type note</span>',
+                    '<span class="htmltypenote">HTML type note</span>'
+                ])
+            }
+        }
+    }
+}, {
+    method: 'GET',
     path: '/withexample',
     config: {
         handler: handler,


### PR DESCRIPTION
Previously notes would concatenate using array.toString causing poor rendering for people who use the notes array options that are available in hapi and joi.
