### PR TITLE
Partition array display into 3 parts

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -327,9 +327,25 @@ internals.getParamsData = function (param, name, typeName) {
     }
 
     if (data.type === 'array' && param.items) {
-        data.items = param.items.map(function (item) {
 
-            return internals.getParamsData(item);
+        if (param.orderedItems) {
+            data.orderedItems = param.orderedItems.map(function (item) {
+
+                return internals.getParamsData(item);
+            });
+        }
+
+        data.items = [];
+        data.forbiddenItems = [];
+        param.items.forEach(function (item) {
+
+            item = internals.getParamsData(item);
+            if (item.flags && item.flags.forbidden) {
+                data.forbiddenItems.push(item);
+            }
+            else {
+                data.items.push(item);
+            }
         });
     }
 

--- a/templates/type.html
+++ b/templates/type.html
@@ -32,7 +32,30 @@
                 {{~#if (exists this.items) ~}}
                     <span class="token-open">[</span>
                     <ul class="list-unstyled list-items">
-                        {{~#each this.items}}{{> type}}{{/each~}}
+                        {{#if this.orderedItems}}
+                            <li>
+                                <div>Ordered:</div>
+                                <ol class="list-unstyled list-items">
+                                    {{~#each this.orderedItems}}{{> type}}{{/each~}}
+                                </ol>
+                            </li>
+                        {{/if}}
+
+                        <li>
+                            <div>{{#if this.orderedItems}}Followed by any:{{else}}Any of:{{/if}}</div>
+                            <ul class="list-unstyled list-items">
+                                {{~#each this.items}}{{> type}}{{/each~}}
+                            </ul>
+                        </li>
+
+                        {{#if this.forbiddenItems}}
+                            <li>
+                                <div>None of:</div>
+                                <ul class="list-unstyled list-items">
+                                    {{~#each this.forbiddenItems}}{{> type}}{{/each~}}
+                                </ul>
+                            </li>
+                        {{/if}}
                     </ul>
                     <span class="token-close">]</span>
                 {{~/if~}}

--- a/templates/type.html
+++ b/templates/type.html
@@ -34,7 +34,7 @@
                     <ul class="list-unstyled list-items">
                         {{#if this.orderedItems}}
                             <li>
-                                <div>Ordered:</div>
+                                <div class="text-danger">Ordered:</div>
                                 <ol class="list-unstyled list-items">
                                     {{~#each this.orderedItems}}{{> type}}{{/each~}}
                                 </ol>
@@ -42,7 +42,7 @@
                         {{/if}}
 
                         <li>
-                            <div>{{#if this.orderedItems}}Followed by any:{{else}}Any of:{{/if}}</div>
+                            <div class="text-danger">{{#if this.orderedItems}}Followed by any:{{else}}Any of:{{/if}}</div>
                             <ul class="list-unstyled list-items">
                                 {{~#each this.items}}{{> type}}{{/each~}}
                             </ul>
@@ -50,7 +50,7 @@
 
                         {{#if this.forbiddenItems}}
                             <li>
-                                <div>None of:</div>
+                                <div class="text-danger">None of:</div>
                                 <ul class="list-unstyled list-items">
                                     {{~#each this.forbiddenItems}}{{> type}}{{/each~}}
                                 </ul>
@@ -60,7 +60,7 @@
                     <span class="token-close">]</span>
                 {{~/if~}}
                 {{#if this.alternatives}}
-                    <span class="token-before-open">Any of </span><span class="token-open">(</span>
+                    <span class="token-before-open text-danger">Any of </span><span class="token-open">(</span>
                     <ul class="list-unstyled list-children field-alternatives">
                         {{#each this.alternatives}}{{> type}}{{/each}}
                     </ul>

--- a/test/routes/default.js
+++ b/test/routes/default.js
@@ -135,6 +135,26 @@ module.exports = [{
     }
 }, {
     method: 'GET',
+    path: '/complexarray',
+    config: {
+        handler: handler,
+        validate: {
+            query: Joi.array()
+            .ordered('foo', 'bar')
+            .items(
+                Joi.string().required(),
+                Joi.string().valid('four').forbidden(),
+                Joi.object({ param1: Joi.number() }),
+                Joi.number().forbidden()
+            ).min(2).max(5).length(3)
+            .ordered('bar', 'bar')
+            .items(
+                Joi.number().required()
+            )
+        }
+    }
+}, {
+    method: 'GET',
     path: '/path/{pparam}/test',
     config: {
         handler: handler,


### PR DESCRIPTION
Create separate list for ordered, unordered, and forbidden items within arrays.

![image](https://cloud.githubusercontent.com/assets/196390/10712782/6be2b446-7a69-11e5-8de4-ea369b74e7b3.png)

Is what I'm working with right now. This also updates the non-ordered case to the following:
![image](https://cloud.githubusercontent.com/assets/196390/10712812/5e82567a-7a6a-11e5-9437-e901be0479bf.png)

I feel like there could be some improvements here, but I'm not sure what exactly. Feels potentially confusing with the alternatives UI. Opening PR to start discussion there.

Fixes #130
