### PR TITLE
expose route settings to filterRoutes function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -152,6 +152,7 @@ internals.docs = function (settings, server) {
                         (!settings.filterRoutes || settings.filterRoutes({
                             method: item.method,
                             path: item.path,
+                            settings: item.settings,
                             connection: connection
                         }));
                 }).sort((route1, route2) => {


### PR DESCRIPTION
We need this to be able to filter on what auth strategy the route has.

Not sure where to add this to the tests? In the `ignores methods` test?
