### PR TITLE
Adding Tag Filtering and Clickable tags.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -179,7 +179,7 @@ internals.docs = function (settings, server) {
                 return reply.view(settings.routeTemplate, internals.getRoutesData(connections[0].table));
             }
 
-            return reply.view(settings.indexTemplate, internals.getConnectionsData(connections));
+            return reply.view(settings.indexTemplate, internals.getConnectionsData(connections, request.query.tag));
         },
         plugins: {
             lout: false
@@ -188,20 +188,20 @@ internals.docs = function (settings, server) {
 };
 
 
-internals.getConnectionsData = function (connections) {
+internals.getConnectionsData = function (connections, tag) {
 
     connections.forEach((connection) => {
 
-        connection.table = internals.getRoutesData(connection.table);
+        connection.table = internals.getRoutesData(connection.table, tag);
     });
 
     return connections;
 };
 
 
-internals.getRoutesData = function (routes) {
+internals.getRoutesData = function (routes, tag) {
 
-    return routes.map((route) => ({
+    let routeMap = routes.map((route) => ({
         path: route.path,
         method: route.method.toUpperCase(),
         description: route.settings.description,
@@ -217,6 +217,15 @@ internals.getRoutesData = function (routes) {
         responseParams: internals.describe(route.settings.response.schema),
         statusSchema: internals.describeStatusSchema(route.settings.response.status)
     }));
+
+    if (tag) {
+        routeMap = routeMap.filter((route) => {
+
+            return (route.tags && route.tags.indexOf(tag) !== -1);
+        });
+    }
+
+    return routeMap;
 };
 
 internals.describe = function (params) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -20,20 +20,25 @@
         <pre class="h3 server-uri-block"><span class="text-muted server-uri-prefix">Routes for </span><span class="server-uri">{{this.info.uri}}</span></pre>
         <div class="route-index">
             {{#each this.table}}
-            <a href="?server={{../info.uri}}&path={{this.path}}#{{this.method}}">
+
                 <div class="row route">
-                    <div class="col-md-2 h2">
-                        <span class="{{colorFromMethod this}} full-width-label">
-                            {{this.method}}
-                        </span>
-                    </div>
-                    <div class="col-md-10 h2">
+                    <a href="?server={{../info.uri}}&path={{this.path}}#{{this.method}}">
+                        <div class="col-md-2 h2">
+                            <span class="{{colorFromMethod this}} full-width-label">
+                                {{this.method}}
+                            </span>
+                        </div>
+                        <div class="col-md-8 h2">
+
+                            {{this.path}}
+                        </div>
+                    </a>
+                    <div class="col-md-1 h2">
                         <div class="pull-right">
                             {{#each this.tags}}
-                            <div class="badge">{{this}}</div>
+                            <a href="?tag={{this}}"><span class="badge">{{this}}</span></a>
                             {{/each}}
                         </div>
-                        {{this.path}}
                     </div>
                 </div>
             </a>

--- a/templates/index.html
+++ b/templates/index.html
@@ -28,12 +28,11 @@
                                 {{this.method}}
                             </span>
                         </div>
-                        <div class="col-md-8 h2">
-
-                            {{this.path}}
-                        </div>
                     </a>
-                    <div class="col-md-1 h2">
+                    <div class="col-md-10">
+                        <a href="?server={{../info.uri}}&path={{this.path}}#{{this.method}}">
+                            <div class="h2 pull-left">{{this.path}}</div>
+                        </a>
                         <div class="pull-right">
                             {{#each this.tags}}
                             <a href="?tag={{this}}"><span class="badge">{{this}}</span></a>

--- a/test/index.js
+++ b/test/index.js
@@ -1096,14 +1096,14 @@ describe('Multiple paths', () => {
             server.inject('/docs/v1', (resv1) => {
 
                 const $ = Cheerio.load(resv1.result);
-                expect($('.route-index > a').length).to.equal(1);
-                expect($('.route-index > a').attr('href')).to.equal('?server=http://test&path=/v1/test#GET');
+                expect($('.route-index .row > a').length).to.equal(1);
+                expect($('.route-index .row > a').attr('href')).to.equal('?server=http://test&path=/v1/test#GET');
 
                 server.inject('/docs/v2', (resv2) => {
 
                     const $$ = Cheerio.load(resv2.result);
-                    expect($$('.route-index > a').length).to.equal(1);
-                    expect($$('.route-index > a').attr('href')).to.equal('?server=http://test&path=/v2/test#GET');
+                    expect($$('.route-index .row > a').length).to.equal(1);
+                    expect($$('.route-index .row > a').attr('href')).to.equal('?server=http://test&path=/v2/test#GET');
 
                     server.inject('/docs', (res) => {
 

--- a/test/index.js
+++ b/test/index.js
@@ -262,6 +262,24 @@ describe('Lout', () => {
         });
     });
 
+    it('filters the index if the tag is provided', (done) => {
+
+        server.inject('/docs?tag=testTag', (res) => {
+
+            server.table()[0].table.forEach((route) => {
+
+                if (route.path !== '/another/test') {
+
+                    expect(res.result).to.not.contain(`?server=http://test&path=${route.path}`);
+                }
+                else {
+                    expect(res.result).to.contain(`?server=http://test&path=${route.path}`);
+                }
+            });
+            done();
+        });
+    });
+
     it('displays the index even with an unknown query param', (done) => {
 
         server.inject('/docs?foo=bar', (res) => {

--- a/test/routes/default.js
+++ b/test/routes/default.js
@@ -27,7 +27,8 @@ module.exports = [{
             query: Joi.object({
                 param1: Joi.string().required()
             })
-        }
+        },
+        tags: ['testTag']
     }
 }, {
     method: 'GET',


### PR DESCRIPTION
This PR adds a `tag` query parameter that get's passed to the `getRouteData` function. If the parameter exists, the routes are then filtered by the given tag.

Also added anchors to the tag badges on the `index.html` for passing the tag query var.
