### PR TITLE
encodeUri handlebars helper

### DIFF
--- a/templates/helpers/encodeUri.js
+++ b/templates/helpers/encodeUri.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const Handlebars = require('handlebars');
+
+module.exports = function (uri) {
+
+  return new Handlebars.SafeString(encodeURI(uri));
+};

--- a/templates/helpers/encodeUri.js
+++ b/templates/helpers/encodeUri.js
@@ -4,5 +4,5 @@ const Handlebars = require('handlebars');
 
 module.exports = function (uri) {
 
-  return new Handlebars.SafeString(encodeURI(uri));
+    return new Handlebars.SafeString(encodeURI(uri));
 };

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,7 +18,7 @@
     <div class="container">
         <div class="route-index">
             {{#each this}}
-            <a href="?path={{encodeUri this.path}}#{{encodeUri this.method}}">
+            <a href="?path={{encodeUri this.path}}#{{this.method}}">
                 <div class="row route">
                     <div class="col-md-2 h2">
                         <span class="{{colorFromMethod this}} full-width-label">

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,7 +18,7 @@
     <div class="container">
         <div class="route-index">
             {{#each this}}
-            <a href="?path={{this.path}}#{{this.method}}">
+            <a href="?path={{encodeUri this.path}}#{{encodeUri this.method}}">
                 <div class="row route">
                     <div class="col-md-2 h2">
                         <span class="{{colorFromMethod this}} full-width-label">

--- a/test/index.js
+++ b/test/index.js
@@ -196,10 +196,10 @@ describe('Lout', () => {
                 route.path === '/docs' ||
                 route.method === 'options') {
 
-                expect(res.result).to.not.contain(`?path=${route.path}`);
+                expect(res.result).to.not.contain(`?path=${encodeURI(route.path)}`);
             }
             else {
-                expect(res.result).to.contain(`?path=${route.path}`);
+                expect(res.result).to.contain(`?path=${encodeURI(route.path)}`);
             }
         });
     });
@@ -214,10 +214,10 @@ describe('Lout', () => {
                 route.path === '/docs' ||
                 route.method === 'options') {
 
-                expect(res.result).to.not.contain(`?path=${route.path}`);
+                expect(res.result).to.not.contain(`?path=${encodeURI(route.path)}`);
             }
             else {
-                expect(res.result).to.contain(`?path=${route.path}`);
+                expect(res.result).to.contain(`?path=${encodeURI(route.path)}`);
             }
         });
     });
@@ -551,9 +551,9 @@ describe('Lout', () => {
             server = Hapi.server();
 
             server.auth.scheme('testScheme', () => ({
-                async authenticate() {},
-                async payload() {},
-                async response() {}
+                async authenticate() { },
+                async payload() { },
+                async response() { }
             }));
             server.auth.strategy('testStrategy', 'testScheme');
             server.auth.default('testStrategy');
@@ -680,7 +680,7 @@ describe('Customized Lout', () => {
             engines: {
                 custom: {
                     module: {
-                        compile() {}
+                        compile() { }
                     }
                 }
             }
@@ -741,17 +741,17 @@ describe('Multiple paths', () => {
         server.route({
             method: 'GET',
             path: '/v1/test',
-            handler() {}
+            handler() { }
         });
         server.route({
             method: 'GET',
             path: '/v2/test',
-            handler() {}
+            handler() { }
         });
         server.route({
             method: 'GET',
             path: '/another',
-            handler() {}
+            handler() { }
         });
 
         await internals.bootstrapServer(server, [{


### PR DESCRIPTION
I am having an issue when deploying my Hapi API on AWS Lambda with lout documentation.  API Gateway doesn't like the characters `{` and `}` in the documentation link for a route that has path parameters.

Here is the [link to the RFC](https://tools.ietf.org/html/rfc1738#section-2.2).
>Other characters are unsafe because
   gateways and other transport agents are known to sometimes modify
   such characters. These characters are "{", "}", "|", "\", "^", "~",
   "[", "]", and "`".

An example docs link that is currently generated would be the following: `/docs?path=/one/{paramTwo}/three/{paramFour}/five#GET`

I took a shot at adding a Handlebars helper for URL encoding that link.